### PR TITLE
feat(server): add local2API support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 const merge = require('webpack-merge');
 const common = require('./webpack.common');
-const devConfig = require('./webpack.dev');
+const dev = require('./webpack.dev');
 const prodConfig = require('./webpack.prod');
 
 module.exports = (opts, env = {}) => {
   const commonConfig = common(opts);
+  const devConfig = dev(env);
   const config = merge(commonConfig, env.production ? prodConfig : devConfig);
 
   return {

--- a/server/proxy/aapi/index.js
+++ b/server/proxy/aapi/index.js
@@ -1,0 +1,16 @@
+const config = {
+  aapi: {
+    url: 'http://localhost:8080',
+  },
+};
+
+module.exports = {
+  context: ['/engine/2api'],
+  target: config.aapi.url,
+  changeOrigin: true,
+  pathRewrite: {
+    '^/engine/2api/': '/',
+  },
+  secure: false,
+  logLevel: 'debug',
+};

--- a/server/proxy/index.js
+++ b/server/proxy/index.js
@@ -1,0 +1,5 @@
+const aapi = require('./aapi');
+
+module.exports = {
+  aapi,
+};

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,29 +1,37 @@
 const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const sso = require('./server/sso');
+const serverProxy = require('./server/proxy');
 
-module.exports = {
-  mode: 'development',
-  plugins: [
-    new DuplicatePackageCheckerPlugin(),
-    new FriendlyErrorsWebpackPlugin(),
-  ],
-  devServer: {
-    before(app) {
-      app.get('/auth', sso.auth);
-      app.get('/auth/check', sso.checkAuth);
-    },
-    clientLogLevel: 'none',
-    logLevel: 'silent',
-    https: true,
-    overlay: true,
-    proxy: [
-      {
-        target: 'https://www.ovh.com',
-        context: ['/engine', '/auth'],
-        changeOrigin: true,
-        logLevel: 'silent',
-      },
+const proxyOptions = {
+  target: 'https://www.ovh.com',
+  context: ['/engine', '/auth'],
+  changeOrigin: true,
+  logLevel: 'silent',
+};
+
+module.exports = (env) => {
+  const devProxy = [proxyOptions];
+  if (env.local2API) {
+    devProxy.unshift(serverProxy.aapi);
+  }
+  return {
+    mode: 'development',
+    plugins: [
+      new DuplicatePackageCheckerPlugin(),
+      new FriendlyErrorsWebpackPlugin(),
     ],
-  },
+    devServer: {
+      before(app) {
+        app.get('/auth', sso.auth);
+        app.get('/auth/check', sso.checkAuth);
+      },
+      clientLogLevel: 'none',
+      logLevel: 'silent',
+      https: true,
+      overlay: true,
+      port: 9000,
+      proxy: devProxy,
+    },
+  };
 };


### PR DESCRIPTION
Add the possibility to use local 2API with `--env.local2API`.
The port is changed to `9000`.