### PR TITLE
fix(common): do not exclude ovh modules js sources

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -111,7 +111,7 @@ module.exports = (opts) => {
         // load JS files
         {
           test: /\.js$/,
-          exclude: /node_modules/, // we don't want babel to process vendors files
+          exclude: p => !/ovh-/.test(p) && /node_modules/.test(p), // we don't want babel to process vendors files
           use: [
             {
               loader: 'babel-loader', // babelify JS sources
@@ -130,7 +130,7 @@ module.exports = (opts) => {
         { // inject translation imports into JS source code,
           // given proper ui-router state 'translations' property
           test: /\.js$/,
-          exclude: /node_modules/,
+          exclude: p => !/ovh-/.test(p) && /node_modules/.test(p),
           enforce: 'pre',
           use: [
             {


### PR DESCRIPTION
So we can import ovh-* modules and process them with babel / ui router translations

Not a breaking change