### PR TITLE
fix(dev): remove deprecated logLevel option

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -25,7 +25,6 @@ module.exports = (env) => {
         app.get('/auth/check', sso.checkAuth.bind(sso));
       },
       clientLogLevel: 'none',
-      logLevel: 'silent',
       https: true,
       overlay: true,
       port: 9000,


### PR DESCRIPTION
This option came from the deprecated `webpack-serve` dependency.

ref: https://github.com/webpack-contrib/webpack-serve#optionsloglevel