### PR TITLE
build(deps): upgrade manager-webpack-dev-server to v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/preset-env": "^7.2.3",
     "@ovh-ux/component-rollup-config": "^5.0.0",
-    "@ovh-ux/manager-webpack-dev-server": "^2.0.4",
+    "@ovh-ux/manager-webpack-dev-server": "^2.1.0",
     "acorn": "^6.0.5",
     "acorn-dynamic-import": "^4.0.0",
     "babel-eslint": "^8.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,10 +944,10 @@
     rollup-pluginutils "^2.3.3"
     slash "^2.0.0"
 
-"@ovh-ux/manager-webpack-dev-server@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-webpack-dev-server/-/manager-webpack-dev-server-2.0.4.tgz#6c29d50920947792c3d257ec590a1deb1c6098c0"
-  integrity sha512-IXFBhoEVbh3HfmhmiZnw4y/laO+1lA+a6683LTLpkDmvjGqojhRfTd4qDktZlPrl5s3WUIL3CxidFe3uTAF0Pg==
+"@ovh-ux/manager-webpack-dev-server@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-webpack-dev-server/-/manager-webpack-dev-server-2.1.0.tgz#62ce46f5820d55bb39d1c908e5547afd4103206a"
+  integrity sha512-N+E/HHQrZ2afd1yWuw2J7nGtb9oLv7A6mQWJMQlxN0wgdtlRpVb92MsysTlPpok93/0YBnrwaVkJaZohwvEjzQ==
   dependencies:
     base64url "^3.0.0"
     cookie "^0.3.1"


### PR DESCRIPTION
# Upgrade manager-webpack-dev-server to v2.1.0

### ⚙️ Build

uses: yarn upgrade-interactive --latest
- @ovh-ux/manager-webpack-dev-server@^2.1.0

ref: ovh-ux/manager-webpack-dev-server#20